### PR TITLE
Reproduce the error of lint issue when it is turned on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
+## Issue desc:
+
+If I enable lint by with the following block
+
+```
+
+okbuck {
+    lint {
+        version = '26.3.2'
+    }
+    externalDependencies {
+        downloadInBuck = false
+    }
+}
+
+```
+
+It will break command with `//...` with error
+`/app:lint_release: parameter 'bash': The macro '$(location //:)' could not be expanded:`
+
+Help would be appreciated.
+
+
+
+
 ## How to run
 1. Generate the ./buckw file.
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ task clean(type: Delete) {
 apply plugin: 'com.uber.okbuck'
 okbuck {
     lint {
-        disabled = true
+        version = '26.3.2'
     }
     externalDependencies {
         downloadInBuck = false


### PR DESCRIPTION
/app:lint_release: parameter 'bash': The macro '$(location //:)' could not be expanded: